### PR TITLE
Zugzwang detection enhancement

### DIFF
--- a/src/position.cpp
+++ b/src/position.cpp
@@ -703,6 +703,38 @@ bool Position::gives_check(Move m) const {
   }
 }
 
+void Position::removePawn(Square s, StateInfo& newSt) {
+	assert(&newSt != st);
+	assert(type_of(piece_on(s)) == PAWN);
+
+	std::memcpy(&newSt, st, offsetof(StateInfo, key));
+	newSt.previous = st;
+	st = &newSt;
+
+	Key k = st->previous->key;
+	Piece pc = piece_on(s);
+	st->pawnKey ^= Zobrist::psq[pc][s];
+
+	k ^= Zobrist::psq[pc][s];
+
+	remove_piece(pc, s);
+
+	st->epSquare= SQ_NONE;
+	board[s] = NO_PIECE;
+	st->checkersBB = attackers_to(square<KING>(sideToMove)) & pieces(~sideToMove);
+	set_check_info(st);
+
+	st->materialKey ^= Zobrist::psq[pc][pieceCount[pc]];
+	st->capturedPiece = NO_PIECE;
+	st->key = k;
+}
+
+void Position::undo_removePawn(Square s, Color c) {
+  st = st->previous;
+  Piece pc = make_piece(c, PAWN);
+  put_piece(pc, s);
+}
+
 
 /// Position::do_move() makes a move, and saves all information necessary
 /// to a StateInfo object. The move is assumed to be legal. Pseudo-legal

--- a/src/position.h
+++ b/src/position.h
@@ -132,6 +132,8 @@ public:
   // Doing and undoing moves
   void do_move(Move m, StateInfo& newSt);
   void do_move(Move m, StateInfo& newSt, bool givesCheck);
+  void removePawn(Square s, StateInfo& newSt);
+  void undo_removePawn(Square s, Color c);
   void undo_move(Move m);
   void do_null_move(StateInfo& newSt);
   void undo_null_move();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -315,6 +315,7 @@ void Thread::search() {
 
   size_t multiPV = Options["MultiPV"];
   Skill skill(Options["Skill Level"]);
+  zugzwangMates=0;
 
   // When playing with strength handicap enable MultiPV search that we will
   // use behind the scenes to retrieve a set of possible moves.
@@ -434,7 +435,11 @@ void Thread::search() {
                   }
               }
               else if (bestValue >= beta)
+              {
                   beta = std::min(bestValue + delta, VALUE_INFINITE);
+                  if (zugzwangMates > 5)
+                      zugzwangMates-=100;
+              }
               else
                   break;
 
@@ -789,9 +794,78 @@ namespace {
 
             if (thisThread->nmpMinPly || (abs(beta) < VALUE_KNOWN_WIN && depth < 12 * ONE_PLY))
                 return nullValue;
-
+                
             assert(!thisThread->nmpMinPly); // Recursive verification is not allowed
 
+            thisThread->nmpColor = us;
+            Pawns::Entry* pe;
+            if ( depth > 12 * ONE_PLY
+                   && !inCheck
+        	       && abs(thisThread->rootMoves[0].score) < 4800
+         	       && thisThread->zugzwangMates < 20
+        	       && (pe = Pawns::probe(pos)) != nullptr
+        	       && popcount(pe->passedPawns[us])
+        	       && popcount(pe->passedPawns[us]) <= 2
+                   && popcount(pos.pieces(us)) <= 7
+        	       && popcount(pos.pieces())   <= 12
+        	       && MoveList<LEGAL, KING>(pos).size() < 1)
+            {
+                bool oneOpponentPasser = popcount(pe->passedPawns[~us]) == 1 &&
+                                        !(pos.pieces() & forward_file_bb(~us, lsb(pe->passedPawns[~us])));
+                Bitboard passed = pe->passedPawns[us] & ~pos.blockers_for_king(us) &  ~pos.blockers_for_king(~us);
+                while (passed)
+                {
+                   Square s = pop_lsb(&passed);
+                   Square promo = make_square(file_of(s), us == WHITE ? RANK_8 : RANK_1);
+                   if ((pos.pieces() & between_bb(promo, s)) || promo == pos.square<KING>(us)) // king can't move
+                      continue; // passer blocked
+                   Move directPromotion = make_move(s, promo);
+                   bool killPromo =  (pos.pieces(~us) & promo) || !pos.see_ge(directPromotion); // opponent controls promotion-square
+                   if (!killPromo && !oneOpponentPasser)
+					  continue;
+                   StateInfo s1,s2,s3;
+                   Square p2, p3 = SQ_NONE;
+                   if (oneOpponentPasser && !killPromo)
+                   {
+                       Rank r1 = relative_rank(~us, rank_of(lsb(pe->passedPawns[~us])));
+                       Rank r2 = relative_rank( us, rank_of(s));
+                       if (r2 > r1)
+                         continue; // if our passed is more advanced we will promote earlier and probably defend with success
+                       if (pawn_attack_span(us, s) & pos.pieces(~us, PAWN))
+                       { // pseudo passed pawn: will be passed after levers
+                          p2 = lsb(pawn_attack_span(us, s) & pos.pieces(~us, PAWN));
+                          Bitboard removeLevers = forward_file_bb(~us, p2) & pos.pieces( us, PAWN);
+                          if (removeLevers)
+                          {
+                            p3 = lsb(removeLevers);
+                            pos.removePawn(p2, s2);
+                            pos.removePawn(p3, s3);
+                          }
+                       }
+				   }
+
+                   thisThread->nmpMinPly = MAX_PLY;
+                   pos.removePawn(s, s1);
+                   Move pv1[MAX_PLY+1];
+                   (ss)->pv = pv1;
+                   (ss)->pv[0] = MOVE_NONE;
+                   Depth nd = (oneOpponentPasser && !killPromo) ? depth - R - 2 * ONE_PLY : depth - 4 * ONE_PLY;
+                   Value v = search<PV>(pos, ss, mated_in(0), VALUE_MATED_IN_MAX_PLY, nd , false);
+
+                   pos.undo_removePawn(s, us);
+                   if (p3 != SQ_NONE) // reput the lever pawns
+                      pos.undo_removePawn(p3, us), pos.undo_removePawn(p2, ~us);
+
+                   if (v > mated_in(0) && v < VALUE_MATED_IN_MAX_PLY)
+                   {
+                     thisThread->zugzwangMates++;
+					 thisThread->nmpMinPly = 0;
+                     // Early return here with a low value, this will spotlight this promising variation
+                     return Value(thisThread->rootMoves[0].score * (thisThread->rootPos.side_to_move() != us ? 1 : -1) - 80);
+                   }
+                } // end processing of passed pawns, author: Günther Demetz
+            }
+            
             // Do verification search at high depths, with null move pruning disabled
             // for us, until ply exceeds nmpMinPly.
             thisThread->nmpMinPly = ss->ply + 3 * (depth-R) / 4;

--- a/src/thread.h
+++ b/src/thread.h
@@ -61,7 +61,7 @@ public:
   Material::Table materialTable;
   Endgames endgames;
   size_t pvIdx, pvLast;
-  int selDepth, nmpMinPly;
+  int selDepth, nmpMinPly, zugzwangMates;
   Color nmpColor;
   std::atomic<uint64_t> nodes, tbHits;
 


### PR DESCRIPTION
LTC fixed num games:
http://tests.stockfishchess.org/tests/view/5bb3704a0ebc592439f6d7ef
ELO: 3.51 +-3.8 (95%) LOS: 96.3%
Total: 10000 W: 1642 L: 1541 D: 6817

LTC SPRT:
http://tests.stockfishchess.org/tests/view/5bb3d1240ebc592439f6dfee
LLR: -2.96 (-2.94,2.94) [0.00,5.00]
Total: 15599 W: 2456 L: 2518 D: 10625 
Elo	-0.94 [-4.11,2.32] (95%)

Solves some of the hardest zugzwang-problems

n1QBq1k1/5p1p/5KP1/p7/8/8/8/8 w - - 0 1 finds Bxc7 
n2Bqk2/5p1p/Q4KP1/p7/8/8/8/8 w - - finds Qc8 
n1QBq1k1/5p1p/5KP1/p6p/4p3/8/4P2P/8 w - - 0 1 finds Bxc7 
8/6pp/1K6/N5P1/3N4/8/npn1P3/k7 w - - 0 1 finds Nab3+ 

bench:  5543771